### PR TITLE
Boost.System linker error fix on certain demos and tests.

### DIFF
--- a/demos/rlCollisionDemo/CMakeLists.txt
+++ b/demos/rlCollisionDemo/CMakeLists.txt
@@ -1,3 +1,4 @@
+find_package(Boost REQUIRED COMPONENTS system)
 find_package(OpenGL REQUIRED)
 find_package(SoQt)
 
@@ -71,6 +72,7 @@ if(QT_FOUND AND SoQt_FOUND)
 			${OPENGL_LIBRARIES}
 			${QT_LIBRARIES}
 			${SoQt_LIBRARIES}
+			${Boost_LIBRARIES}
 		)
 		
 		set_target_properties(

--- a/demos/rlPlanDemo/CMakeLists.txt
+++ b/demos/rlPlanDemo/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system)
 find_package(OpenGL REQUIRED)
 find_package(SoQt)
 
@@ -88,6 +88,7 @@ if(QT_FOUND AND SoQt_FOUND AND (Bullet_FOUND OR (CCD_FOUND AND FCL_FOUND) OR ODE
 		${OPENGL_LIBRARIES}
 		${QT_LIBRARIES}
 		${SoQt_LIBRARIES}
+		${Boost_LIBRARIES}
 	)
 	
 	set_target_properties(

--- a/tests/rlCollisionTest/CMakeLists.txt
+++ b/tests/rlCollisionTest/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system)
 
 find_package(Bullet)
 find_package(ccd)
@@ -23,6 +23,7 @@ if(BULLET_FOUND OR (CCD_FOUND AND FCL_FOUND) OR ODE_FOUND OR PQP_FOUND OR SOLID3
 		rlCollisionTest
 		mdl
 		sg
+		${Boost_LIBRARIES}
 	)
 	
 	add_test(
@@ -41,6 +42,7 @@ if(BULLET_FOUND OR (CCD_FOUND AND FCL_FOUND) OR ODE_FOUND OR PQP_FOUND OR SOLID3
 	target_link_libraries(
 		rlSceneCollisionTest
 		sg
+		${Boost_LIBRARIES}
 	)
 	
 	add_test(

--- a/tests/rlEetTest/CMakeLists.txt
+++ b/tests/rlEetTest/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system)
 
 find_package(Bullet)
 find_package(ccd)
@@ -23,6 +23,7 @@ if(BULLET_FOUND OR (CCD_FOUND AND FCL_FOUND) OR PQP_FOUND OR SOLID3_FOUND)
 		plan
 		kin
 		sg
+		${Boost_LIBRARIES}
 	)
 	
 	if(BULLET_FOUND)

--- a/tests/rlPrmTest/CMakeLists.txt
+++ b/tests/rlPrmTest/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system)
 
 find_package(Bullet)
 find_package(ccd)
@@ -24,6 +24,7 @@ if(BULLET_FOUND OR (CCD_FOUND AND FCL_FOUND) OR ODE_FOUND OR PQP_FOUND OR SOLID3
 		plan
 		kin
 		sg
+		${Boost_LIBRARIES}
 	)
 	
 	if(BULLET_FOUND)


### PR DESCRIPTION
Linker error on certain demos and tests regarding Boost.System.

E.g.:
```
/usr/bin/ld: CMakeFiles/rlSceneCollisionTest.dir/rlSceneCollisionTest.cpp.o: undefined reference to symbol '_ZN5boost6system16generic_categoryEv'                                                                                                                                 
/usr/lib/libboost_system.so.1.66.0: error adding symbols: DSO missing from command line                                                                                                                                                                                           
collect2: error: ld returned 1 exit status                                                                                                                                                                                                                                        
make[2]: *** [tests/rlCollisionTest/CMakeFiles/rlSceneCollisionTest.dir/build.make:110: tests/rlCollisionTest/rlSceneCollisionTest] Error 1                                                                                                                                       
make[1]: *** [CMakeFiles/Makefile2:3686: tests/rlCollisionTest/CMakeFiles/rlSceneCollisionTest.dir/all] Error 2                                                                                                                                                                   
make[1]: *** Waiting for unfinished jobs....
```

System:
OS: Arch Linux x64
GCC: 7.2.1
CMake: 3.10.1
Make: GNU Make 4.2.1
Boost: 1.66.0

Proposed solution:
Add a library link for Boost (System) to the following files:
rl\tests\rlCollisionTest\CMakeLists.txt
rl\tests\rlEetTest\CMakeLists.txt
rl\tests\rlPrmTest\CMakeLists.txt
rl\demos\rlCollisionDemo\CMakeLists.txt
rl\demos\rlPlanDemo\CMakeLists.txt

Greetings,
S. Broekman