### PR TITLE
Fix generation of uniform position in mdl::Model for Spherical joints

### DIFF
--- a/src/rl/mdl/Model.cpp
+++ b/src/rl/mdl/Model.cpp
@@ -134,9 +134,9 @@ namespace rl
 		{
 			::rl::math::Vector q(this->getDofPosition());
 			
-			for (::std::size_t i = 0, j = 0; i < this->joints.size(); j += this->joints[i]->getDofPosition(), ++i)
+			for (::std::size_t i = 0, j = 0, k=0; i < this->joints.size(); j += this->joints[i]->getDofPosition(), k += this->joints[i]->getDof(), ++i)
 			{
-				q.segment(j, this->joints[i]->getDofPosition()) = this->joints[i]->generatePositionUniform(rand.segment(j, this->joints[i]->getDofPosition()));
+				q.segment(j, this->joints[i]->getDofPosition()) = this->joints[i]->generatePositionUniform(rand.segment(k, this->joints[i]->getDof()));
 			}
 			
 			return q;


### PR DESCRIPTION
Hi there,
I'm a new user of rl and I stumbled upon that little bug which made the program crash when generating a uniform position for a Spherical joint. So I fixed it in line with how this is done in generatePositionGaussian.

Thanks for the good work anyway!