### PR TITLE
Allow downstream code to use the eigen plugin system

### DIFF
--- a/src/rl/math/MatrixBaseAddons.h
+++ b/src/rl/math/MatrixBaseAddons.h
@@ -332,4 +332,8 @@ voigt33() const
 } }
 #endif
 
+#ifdef RL_EIGEN_MATRIXBASE_PLUGIN
+# include RL_EIGEN_MATRIXBASE_PLUGIN
+#endif
+
 #endif // RL_MATH_MATRIXBASEADDONS_H

--- a/src/rl/math/QuaternionBaseAddons.h
+++ b/src/rl/math/QuaternionBaseAddons.h
@@ -307,4 +307,8 @@ squadFirstDerivative(const Scalar& t, const QuaternionBase<OtherDerived1>& a, co
 } }
 #endif
 
+#ifdef RL_EIGEN_QUATERNIONBASE_PLUGIN
+# include RL_EIGEN_QUATERNIONBASE_PLUGIN
+#endif
+
 #endif // RL_MATH_QUATERNIONBASEADDONS_H

--- a/src/rl/math/TransformAddons.h
+++ b/src/rl/math/TransformAddons.h
@@ -230,4 +230,9 @@ toDenavitHartenbergPaul(OtherScalar1& d, OtherScalar2& theta, OtherScalar3& a, O
 } }
 #endif
 
+
+#ifdef RL_EIGEN_TRANSFORM_PLUGIN
+# include RL_EIGEN_TRANSFORM_PLUGIN
+#endif
+
 #endif // RL_MATH_TRANSFORMADDONS_H


### PR DESCRIPTION
rl hardcodes its Eigen plugin rather than using the build system as recommended in the Eigen docs. This blocks downstream users of rl & Eigen from using the Eigen plugins.

Assuming that the hardcoding was an intentional choice, this pull request gives downstream users the ability insert their plugins. 