### PR TITLE
fix bugs in path optimizers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,31 +8,10 @@ jobs:
       fail-fast: false
       matrix:
         name:
-#          - macos-11
-#          - ubuntu-20.04-clang
-#          - ubuntu-20.04-gcc
           - windows-2019-msvc
-#          - windows-2019-msys2
         include:
-#          - name: macos-11
-#            cmake_compiler_launcher: ccache
-#            cmake_prefix_path: /usr/local/opt/qt/lib/cmake
-#            os: macos-11
-#          - name: ubuntu-20.04-clang
-#            cc: clang
-#            cmake_compiler_launcher: ccache
-#            cxx: clang++
-#            os: ubuntu-20.04
-#          - name: ubuntu-20.04-gcc
-#            cc: gcc
-#            cmake_compiler_launcher: ccache
-#            cxx: g++
-#            os: ubuntu-20.04
           - name: windows-2019-msvc
             os: windows-2019
-#          - name: windows-2019-msys2
-#            cmake_compiler_launcher: ccache
-#            os: windows-2019
     env:
       CC: ${{ matrix.cc }}
       CCACHE_COMPRESS: true
@@ -151,21 +130,21 @@ jobs:
           cmake
           -G"Ninja Multi-Config"
           -S"${{ github.workspace }}"
-          -B"${{ github.workspace }}/build"
+          -B"${{ runner.workspace }}/rl-build"
       - name: Build Debug
-        working-directory: ${{ github.workspace }}/build
+        working-directory: ${{ runner.workspace }}/rl-build
         run: cmake --build . --config Debug
       - name: Build Release
-        working-directory: ${{ github.workspace }}/build
+        working-directory: ${{ runner.workspace }}/rl-build
         run: cmake --build . --config Release
       - name: Test
-        working-directory: ${{ github.workspace }}/build
+        working-directory: ${{ runner.workspace }}/rl-build
         run: ctest --output-on-failure
       - name: Create archive
-        working-directory: ${{ github.workspace }}/build
+        working-directory: ${{ runner.workspace }}/rl-build
         run: cpack -G 7Z
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.name }}
-          path: ${{ github.workspace }}/build/rl-*.7z
+          path: ${{ runner.workspace }}/rl-build/rl-*.7z

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
         name: Install dependencies for MSVC
         working-directory: ${{ runner.workspace }}
         run: |
-          curl -L https://github.com/Kazfyx/rl-3rdparty/releases/download/latest/rl-3rdparty-msvc-14.2-x64.7z -o rl-3rdparty-msvc-14.2-x64.7z
+          curl -L https://github.com/roboticslibrary/rl-3rdparty/releases/download/latest/rl-3rdparty-msvc-14.2-x64.7z -o rl-3rdparty-msvc-14.2-x64.7z
           7z x rl-3rdparty-msvc-14.2-x64.7z -orl-3rdparty-install
           Write-Output "${{ runner.workspace }}\rl-3rdparty-install\bin" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
       - if: matrix.name == 'windows-2019-msys2'
@@ -149,7 +149,7 @@ jobs:
       - name: Configure CMake
         run: >
           cmake
-          -GNinja
+          -G"Ninja Multi-Config"
           -S"${{ github.workspace }}"
           -B"${{ github.workspace }}/build"
       - name: Build Debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,5 @@
 name: CI
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: workflow_dispatch
 jobs:
   build:
     name: Build
@@ -14,31 +8,31 @@ jobs:
       fail-fast: false
       matrix:
         name:
-          - macos-11
-          - ubuntu-20.04-clang
-          - ubuntu-20.04-gcc
+#          - macos-11
+#          - ubuntu-20.04-clang
+#          - ubuntu-20.04-gcc
           - windows-2019-msvc
-          - windows-2019-msys2
+#          - windows-2019-msys2
         include:
-          - name: macos-11
-            cmake_compiler_launcher: ccache
-            cmake_prefix_path: /usr/local/opt/qt/lib/cmake
-            os: macos-11
-          - name: ubuntu-20.04-clang
-            cc: clang
-            cmake_compiler_launcher: ccache
-            cxx: clang++
-            os: ubuntu-20.04
-          - name: ubuntu-20.04-gcc
-            cc: gcc
-            cmake_compiler_launcher: ccache
-            cxx: g++
-            os: ubuntu-20.04
+#          - name: macos-11
+#            cmake_compiler_launcher: ccache
+#            cmake_prefix_path: /usr/local/opt/qt/lib/cmake
+#            os: macos-11
+#          - name: ubuntu-20.04-clang
+#            cc: clang
+#            cmake_compiler_launcher: ccache
+#            cxx: clang++
+#            os: ubuntu-20.04
+#          - name: ubuntu-20.04-gcc
+#            cc: gcc
+#            cmake_compiler_launcher: ccache
+#            cxx: g++
+#            os: ubuntu-20.04
           - name: windows-2019-msvc
             os: windows-2019
-          - name: windows-2019-msys2
-            cmake_compiler_launcher: ccache
-            os: windows-2019
+#          - name: windows-2019-msys2
+#            cmake_compiler_launcher: ccache
+#            os: windows-2019
     env:
       CC: ${{ matrix.cc }}
       CCACHE_COMPRESS: true
@@ -106,7 +100,7 @@ jobs:
         name: Install dependencies for MSVC
         working-directory: ${{ runner.workspace }}
         run: |
-          curl -L https://github.com/roboticslibrary/rl-3rdparty/releases/download/latest/rl-3rdparty-msvc-14.2-x64.7z -o rl-3rdparty-msvc-14.2-x64.7z
+          curl -L https://github.com/Kazfyx/rl-3rdparty/releases/download/latest/rl-3rdparty-msvc-14.2-x64.7z -o rl-3rdparty-msvc-14.2-x64.7z
           7z x rl-3rdparty-msvc-14.2-x64.7z -orl-3rdparty-install
           Write-Output "${{ runner.workspace }}\rl-3rdparty-install\bin" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
       - if: matrix.name == 'windows-2019-msys2'
@@ -155,13 +149,15 @@ jobs:
       - name: Configure CMake
         run: >
           cmake
-          -GNinja
-          -DCMAKE_BUILD_TYPE=Release
+          -G"Ninja Multi-Config"
           -S"${{ github.workspace }}"
           -B"${{ runner.workspace }}/rl-build"
-      - name: Build
+      - name: Build Debug
         working-directory: ${{ runner.workspace }}/rl-build
-        run: cmake --build .
+        run: cmake --build . --config Debug
+      - name: Build Release
+        working-directory: ${{ runner.workspace }}/rl-build
+        run: cmake --build . --config Release
       - name: Test
         working-directory: ${{ runner.workspace }}/rl-build
         run: ctest --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,23 +149,23 @@ jobs:
       - name: Configure CMake
         run: >
           cmake
-          -G"Ninja Multi-Config"
+          -GNinja
           -S"${{ github.workspace }}"
-          -B"${{ runner.workspace }}/rl-build"
+          -B"${{ github.workspace }}/build"
       - name: Build Debug
-        working-directory: ${{ runner.workspace }}/rl-build
+        working-directory: ${{ github.workspace }}/build
         run: cmake --build . --config Debug
       - name: Build Release
-        working-directory: ${{ runner.workspace }}/rl-build
+        working-directory: ${{ github.workspace }}/build
         run: cmake --build . --config Release
       - name: Test
-        working-directory: ${{ runner.workspace }}/rl-build
+        working-directory: ${{ github.workspace }}/build
         run: ctest --output-on-failure
       - name: Create archive
-        working-directory: ${{ runner.workspace }}/rl-build
+        working-directory: ${{ github.workspace }}/build
         run: cpack -G 7Z
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.name }}
-          path: ${{ runner.workspace }}/rl-build/rl-*.7z
+          path: ${{ github.workspace }}/build/rl-*.7z

--- a/src/rl/plan/AdvancedOptimizer.cpp
+++ b/src/rl/plan/AdvancedOptimizer.cpp
@@ -62,13 +62,21 @@ namespace rl
 			bool changed = true;
 			::rl::math::Vector inter(this->getModel()->getDofPosition());
 			
+			VectorList::iterator i;
+			VectorList::iterator j;
+			VectorList::iterator k;
+			
 			while (changed && path.size() > 2)
 			{
 				while (changed && path.size() > 2)
 				{
 					changed = false;
 					
-					for (VectorList::iterator i = path.begin(), j = ::std::next(i), k = ::std::next(j); i != path.end() && j != path.end() && k != path.end(); ++i, ++j, ++k)
+					i = path.begin();
+					j = ++path.begin();
+					k = ++++path.begin();
+					
+					while (i != path.end() && j != path.end() && k != path.end())
 					{
 						::rl::math::Real ik = this->getModel()->distance(*i, *k);
 						
@@ -76,7 +84,11 @@ namespace rl
 						{
 							::rl::math::Real ij = this->getModel()->distance(*i, *j);
 							::rl::math::Real jk = this->getModel()->distance(*j, *k);
-							this->getModel()->interpolate(*i, *k, ij / (ij + jk), inter);
+							
+							::rl::math::Real alpha = ij / (ij + jk);
+							
+							this->getModel()->interpolate(*i, *k, alpha, inter);
+							
 							::rl::math::Real ratio = this->getModel()->distance(*j, inter) / ik;
 							
 							if (ratio > this->ratio)
@@ -93,6 +105,18 @@ namespace rl
 								
 								changed = true;
 							}
+							else
+							{
+								++i;
+								++j;
+								++k;
+							}
+						}
+						else
+						{
+							++i;
+							++j;
+							++k;
 						}
 					}
 				}

--- a/src/rl/plan/Optimizer.cpp
+++ b/src/rl/plan/Optimizer.cpp
@@ -85,12 +85,16 @@ namespace rl
 			bool changed = false;
 			::rl::math::Vector inter(this->getModel()->getDofPosition());
 			
-			for (VectorList::iterator i = path.begin(), j = ::std::next(i); i != path.end() && j != path.end(); ++i, ++j)
+			VectorList::iterator i = path.begin();
+			VectorList::iterator j = ++path.begin();
+				
+			while (i != path.end() && j != path.end())
 			{
-				if (0 == length || this->getModel()->distance(*i, *j) > length)
+				if (length > 0 && this->getModel()->distance(*i, *j) > length)
 				{
 					this->getModel()->interpolate(*i, *j, static_cast<::rl::math::Real>(0.5), inter);
-					i = path.insert(j, inter);
+					
+					j = path.insert(j, inter);
 					
 					if (nullptr != this->getViewer())
 					{
@@ -98,6 +102,11 @@ namespace rl
 					}
 					
 					changed = true;
+				}
+				else
+				{
+					++i;
+					++j;
 				}
 			}
 			

--- a/src/rl/plan/SimpleOptimizer.cpp
+++ b/src/rl/plan/SimpleOptimizer.cpp
@@ -51,7 +51,11 @@ namespace rl
 			{
 				changed = false;
 				
-				for (VectorList::iterator i = path.begin(), j = ::std::next(i), k = ::std::next(j); i != path.end() && j != path.end() && k != path.end(); ++i, ++j, ++k)
+				VectorList::iterator i = path.begin();
+				VectorList::iterator j = ++path.begin();
+				VectorList::iterator k = ++++path.begin();
+				
+				while (i != path.end() && j != path.end() && k != path.end())
 				{
 					::rl::math::Real ik = this->getModel()->distance(*i, *k);
 					
@@ -68,6 +72,12 @@ namespace rl
 						}
 						
 						changed = true;
+					}
+					else
+					{
+						++i;
+						++j;
+						++k;
 					}
 				}
 			}


### PR DESCRIPTION
In the simple optimizer and advanced optimizer, some iterators are increased in the loop body. But at the end of each loop in a for-loop structure, these iterators will be increased again. When the program is running in debug mode, an assertion will occur that an iterator is behind the end(). I think this is not the real intention of the developers, and it would not get a correct optimization result.
