### PR TITLE
fix iterator bugs in path optimizers

### DIFF
--- a/src/rl/plan/AdvancedOptimizer.cpp
+++ b/src/rl/plan/AdvancedOptimizer.cpp
@@ -61,7 +61,7 @@ namespace rl
 		{
 			bool changed = true;
 			::rl::math::Vector inter(this->getModel()->getDofPosition());
-						
+			
 			while (changed && path.size() > 2)
 			{
 				while (changed && path.size() > 2)
@@ -76,11 +76,8 @@ namespace rl
 						{
 							::rl::math::Real ij = this->getModel()->distance(*i, *j);
 							::rl::math::Real jk = this->getModel()->distance(*j, *k);
-							
 							::rl::math::Real alpha = ij / (ij + jk);
-							
 							this->getModel()->interpolate(*i, *k, alpha, inter);
-							
 							::rl::math::Real ratio = this->getModel()->distance(*j, inter) / ik;
 							
 							if (ratio > this->ratio)

--- a/src/rl/plan/AdvancedOptimizer.cpp
+++ b/src/rl/plan/AdvancedOptimizer.cpp
@@ -62,13 +62,21 @@ namespace rl
 			bool changed = true;
 			::rl::math::Vector inter(this->getModel()->getDofPosition());
 			
+			VectorList::iterator i;
+			VectorList::iterator j;
+			VectorList::iterator k;
+			
 			while (changed && path.size() > 2)
 			{
 				while (changed && path.size() > 2)
 				{
 					changed = false;
 					
-					for (VectorList::iterator i = path.begin(), j = ::std::next(i), k = ::std::next(j); i != path.end() && j != path.end() && k != path.end(); ++i, ++j, ++k)
+					i = path.begin();
+					j = ++path.begin();
+					k = ++++path.begin();
+					
+					while (i != path.end() && j != path.end() && k != path.end())
 					{
 						::rl::math::Real ik = this->getModel()->distance(*i, *k);
 						
@@ -76,7 +84,11 @@ namespace rl
 						{
 							::rl::math::Real ij = this->getModel()->distance(*i, *j);
 							::rl::math::Real jk = this->getModel()->distance(*j, *k);
-							this->getModel()->interpolate(*i, *k, ij / (ij + jk), inter);
+							
+							::rl::math::Real alpha = ij / (ij + jk);
+							
+							this->getModel()->interpolate(*i, *k, alpha, inter);
+							
 							::rl::math::Real ratio = this->getModel()->distance(*j, inter) / ik;
 							
 							if (ratio > this->ratio)
@@ -93,6 +105,18 @@ namespace rl
 								
 								changed = true;
 							}
+							else
+							{
+								++i;
+								++j;
+								++k;
+							}
+						}
+						else
+						{
+							++i;
+							++j;
+							++k;
 						}
 					}
 				}

--- a/src/rl/plan/AdvancedOptimizer.cpp
+++ b/src/rl/plan/AdvancedOptimizer.cpp
@@ -61,22 +61,14 @@ namespace rl
 		{
 			bool changed = true;
 			::rl::math::Vector inter(this->getModel()->getDofPosition());
-			
-			VectorList::iterator i;
-			VectorList::iterator j;
-			VectorList::iterator k;
-			
+						
 			while (changed && path.size() > 2)
 			{
 				while (changed && path.size() > 2)
 				{
 					changed = false;
 					
-					i = path.begin();
-					j = ++path.begin();
-					k = ++++path.begin();
-					
-					while (i != path.end() && j != path.end() && k != path.end())
+					for (VectorList::iterator i = path.begin(), j = ::std::next(i), k = ::std::next(j); i != path.end() && j != path.end() && k != path.end();)
 					{
 						::rl::math::Real ik = this->getModel()->distance(*i, *k);
 						

--- a/src/rl/plan/Optimizer.cpp
+++ b/src/rl/plan/Optimizer.cpp
@@ -85,12 +85,16 @@ namespace rl
 			bool changed = false;
 			::rl::math::Vector inter(this->getModel()->getDofPosition());
 			
-			for (VectorList::iterator i = path.begin(), j = ::std::next(i); i != path.end() && j != path.end(); ++i, ++j)
+			VectorList::iterator i = path.begin();
+			VectorList::iterator j = ++path.begin();
+				
+			while (i != path.end() && j != path.end())
 			{
-				if (0 == length || this->getModel()->distance(*i, *j) > length)
+				if (length > 0 && this->getModel()->distance(*i, *j) > length)
 				{
 					this->getModel()->interpolate(*i, *j, static_cast<::rl::math::Real>(0.5), inter);
-					i = path.insert(j, inter);
+					
+					j = path.insert(j, inter);
 					
 					if (nullptr != this->getViewer())
 					{
@@ -98,6 +102,11 @@ namespace rl
 					}
 					
 					changed = true;
+				}
+				else
+				{
+					++i;
+					++j;
 				}
 			}
 			

--- a/src/rl/plan/Optimizer.cpp
+++ b/src/rl/plan/Optimizer.cpp
@@ -84,11 +84,8 @@ namespace rl
 		{
 			bool changed = false;
 			::rl::math::Vector inter(this->getModel()->getDofPosition());
-			
-			VectorList::iterator i = path.begin();
-			VectorList::iterator j = ++path.begin();
 				
-			while (i != path.end() && j != path.end())
+			for (VectorList::iterator i = path.begin(), j = ::std::next(i); i != path.end() && j != path.end();)
 			{
 				if (length > 0 && this->getModel()->distance(*i, *j) > length)
 				{

--- a/src/rl/plan/Optimizer.cpp
+++ b/src/rl/plan/Optimizer.cpp
@@ -84,13 +84,12 @@ namespace rl
 		{
 			bool changed = false;
 			::rl::math::Vector inter(this->getModel()->getDofPosition());
-				
+			
 			for (VectorList::iterator i = path.begin(), j = ::std::next(i); i != path.end() && j != path.end();)
 			{
 				if (length > 0 && this->getModel()->distance(*i, *j) > length)
 				{
 					this->getModel()->interpolate(*i, *j, static_cast<::rl::math::Real>(0.5), inter);
-					
 					j = path.insert(j, inter);
 					
 					if (nullptr != this->getViewer())

--- a/src/rl/plan/SimpleOptimizer.cpp
+++ b/src/rl/plan/SimpleOptimizer.cpp
@@ -51,7 +51,11 @@ namespace rl
 			{
 				changed = false;
 				
-				for (VectorList::iterator i = path.begin(), j = ::std::next(i), k = ::std::next(j); i != path.end() && j != path.end() && k != path.end(); ++i, ++j, ++k)
+				VectorList::iterator i = path.begin();
+				VectorList::iterator j = ++path.begin();
+				VectorList::iterator k = ++++path.begin();
+				
+				while (i != path.end() && j != path.end() && k != path.end())
 				{
 					::rl::math::Real ik = this->getModel()->distance(*i, *k);
 					
@@ -68,6 +72,12 @@ namespace rl
 						}
 						
 						changed = true;
+					}
+					else
+					{
+						++i;
+						++j;
+						++k;
 					}
 				}
 			}

--- a/src/rl/plan/SimpleOptimizer.cpp
+++ b/src/rl/plan/SimpleOptimizer.cpp
@@ -51,11 +51,7 @@ namespace rl
 			{
 				changed = false;
 				
-				VectorList::iterator i = path.begin();
-				VectorList::iterator j = ++path.begin();
-				VectorList::iterator k = ++++path.begin();
-				
-				while (i != path.end() && j != path.end() && k != path.end())
+				for (VectorList::iterator i = path.begin(), j = ::std::next(i), k = ::std::next(j); i != path.end() && j != path.end() && k != path.end();)
 				{
 					::rl::math::Real ik = this->getModel()->distance(*i, *k);
 					


### PR DESCRIPTION
In the simple optimizer and advanced optimizer, some iterators are increased in the loop body. But at the end of each loop, these iterators will be increased again by the for-loop structure. When the program is running in debug mode, an assertion often occurs that an iterator is behind the end iterator of a VectorList. I think this is not the real intention of the developers, and it would not get a correct optimization result.