### PR TITLE
fix memory leak when rl::sg::ode::Shape is destroyed

### DIFF
--- a/src/rl/sg/ode/Shape.cpp
+++ b/src/rl/sg/ode/Shape.cpp
@@ -49,10 +49,10 @@ namespace rl
 				::rl::sg::Shape(body),
 				geom(nullptr),
 				baseTransform(::rl::math::Transform::Identity()),
+				data(nullptr),
 				indices(),
 				transform(::rl::math::Transform::Identity()),
-				vertices(),
-				data(nullptr)
+				vertices()
 			{
 				::SoVRMLGeometry* geometry = static_cast<::SoVRMLGeometry*>(shape->geometry.getValue());
 				

--- a/src/rl/sg/ode/Shape.cpp
+++ b/src/rl/sg/ode/Shape.cpp
@@ -92,9 +92,9 @@ namespace rl
 					callbackAction.addTriangleCallback(geometry->getTypeId(), Shape::triangleCallback, this);
 					callbackAction.apply(geometry);
 					
-					::dTriMeshDataID data = ::dGeomTriMeshDataCreate();
+					this->data = ::dGeomTriMeshDataCreate();
 					::dGeomTriMeshDataBuildSimple(data, &this->vertices[0], this->vertices.size() / 4, &this->indices[0], this->indices.size());
-					this->geom = ::dCreateTriMesh(static_cast<Body*>(this->getBody())->space, data, nullptr, nullptr, nullptr);
+					this->geom = ::dCreateTriMesh(static_cast<Body*>(this->getBody())->space, this->data, nullptr, nullptr, nullptr);
 				}
 				else if (geometry->isOfType(::SoVRMLSphere::getClassTypeId()))
 				{
@@ -121,6 +121,7 @@ namespace rl
 			{
 				this->getBody()->remove(this);
 				::dGeomDestroy(this->geom);
+				::dGeomTriMeshDataDestroy(this->data);
 			}
 			
 			::rl::math::Transform

--- a/src/rl/sg/ode/Shape.cpp
+++ b/src/rl/sg/ode/Shape.cpp
@@ -51,7 +51,8 @@ namespace rl
 				baseTransform(::rl::math::Transform::Identity()),
 				indices(),
 				transform(::rl::math::Transform::Identity()),
-				vertices()
+				vertices(),
+				data(nullptr)
 			{
 				::SoVRMLGeometry* geometry = static_cast<::SoVRMLGeometry*>(shape->geometry.getValue());
 				

--- a/src/rl/sg/ode/Shape.h
+++ b/src/rl/sg/ode/Shape.h
@@ -63,13 +63,13 @@ namespace rl
 				
 				::rl::math::Transform baseTransform;
 				
+				::dTriMeshDataID data;
+				
 				::std::vector<::dTriIndex> indices;
 				
 				::rl::math::Transform transform;
 				
 				::std::vector<::dReal> vertices;
-				
-				::dTriMeshDataID data;
 			};
 		}
 	}

--- a/src/rl/sg/ode/Shape.h
+++ b/src/rl/sg/ode/Shape.h
@@ -55,6 +55,8 @@ namespace rl
 				void setTransform(const ::rl::math::Transform& transform);
 				
 				::dGeomID geom;
+
+				::dTriMeshDataID data;
 				
 			protected:
 				

--- a/src/rl/sg/ode/Shape.h
+++ b/src/rl/sg/ode/Shape.h
@@ -55,8 +55,6 @@ namespace rl
 				void setTransform(const ::rl::math::Transform& transform);
 				
 				::dGeomID geom;
-
-				::dTriMeshDataID data;
 				
 			protected:
 				
@@ -70,6 +68,8 @@ namespace rl
 				::rl::math::Transform transform;
 				
 				::std::vector<::dReal> vertices;
+				
+				::dTriMeshDataID data;
 			};
 		}
 	}


### PR DESCRIPTION
I discovered a memory leak when destroying rl::sg::ode::Scene. Upon investigation, I found that the ::dTriMeshDataID created during the creation of rl::sg::ode::Shape was not being destroyed. To correct this, I modified the code as follows.